### PR TITLE
Refactored AttributeObject to be a dynamically created dataclass

### DIFF
--- a/libraries/python/cfengine.py
+++ b/libraries/python/cfengine.py
@@ -3,6 +3,7 @@ import json
 import traceback
 from copy import copy
 from collections import OrderedDict
+from dataclasses import make_dataclass
 
 _LOG_LEVELS = {level: idx for idx, level in enumerate(("critical", "error", "warning", "notice", "info", "verbose", "debug"))}
 
@@ -56,9 +57,9 @@ def _cfengine_type(typing):
 
 
 class AttributeObject(object):
-    def __init__(self, d):
-        for key, value in d.items():
-            setattr(self, key, value)
+    def __new__(self, d):
+        cls = make_dataclass('AttributeObject', d.keys())
+        return cls(**d)
 
 
 class ValidationError(Exception):


### PR DESCRIPTION
By using python's dataclasses we can make the dynamic creation of the
AttributeObject trivial while providing some convinience like a
repr method for free, to ease debugging.

```python
>>> class AttrObj:
...    def __init__(self, d):
...        for k, v in d.items():
...            setattr(self, k, v)
...
... class AttrObjData:
...     def __new__(self, d):
...         obj_cls = make_dataclass('AttrObjData', d.keys())
...         return obj_cls(**d)
...
... attrs = {'attr': 'some value', 'attr2': 123, 'attr3': {'name': 'john', 'age': 123}}
...
... ao = AttrObj(attrs)
... aod = AttrObjData(attrs)
...
... print(ao)
... print(aod)
...
<__main__.AttrObj object at 0x7f705b383d30>
AttrObjData(attr='some value', attr2=123, attr3={'name': 'john', 'age': 123})
```

Ticket: None
Changelog: None
