### PR TITLE
Fixed environment variable logic and added ssh_executable attribute

### DIFF
--- a/promise_types/git/README.md
+++ b/promise_types/git/README.md
@@ -24,6 +24,7 @@
 | `recursive` | `boolean` | If `true`, use the `--recursive` git option | No | `yes` |
 | `reference` | `string` | If set, use the `--reference` git option with the given value | No | - |
 | `remote` | `string` | Name of the git remote | No | `origin` |
+| `ssh_executable` | `string` | Path to the `ssh` executable | No | `ssh` |
 | `ssh_options` | `string` | Additional options for the `git` command, e.g. `-o StrictHostKeyChecking=no` | No | - |
 | `update` | `boolean` | If `true`, updates the repository if it already exists at the destination path | No | - |
 | `version` | `string` | The version of the repository to checkout. It can be a branch name, a tag name or a SHA-1 hash. | No | `HEAD` |

--- a/promise_types/git/git.py
+++ b/promise_types/git/git.py
@@ -29,6 +29,7 @@ class GitPromiseTypeModule(PromiseModule):
         self.add_attribute("recursive", bool, default=True)
         self.add_attribute("reference", str)
         self.add_attribute("remote", str, default="origin")
+        self.add_attribute("ssh_executable", str, default="ssh")
         self.add_attribute("ssh_options", str)
         self.add_attribute("update", bool, default=True)
         self.add_attribute("version", str, default="HEAD")
@@ -191,7 +192,7 @@ class GitPromiseTypeModule(PromiseModule):
 
     def _git_envvars(self, model: object):
         env = os.environ.copy()
-        env["GIT_SSH_COMMAND"] = f"{model.executable}"
+        env["GIT_SSH_COMMAND"] = model.ssh_executable
         if model.ssh_options:
             env["GIT_SSH_COMMAND"] += " " + model.ssh_options
         return env


### PR DESCRIPTION
Running the following promise with the original code will lead to errors.

```cfengine3
bundle agent main
{
  git:
    "cxxvector"
      repository => "git@github.com:KotzaBoss/CXXVector.git",
      destination => "/tmp/CXXVector",
      ssh_options => "-i /home/__alias__/.ssh/id_rsa",
      version => "master";
}
```

By putting a simple logging after setting up the environment:

```python
def _git_envvars(self, model: object):
    ...
    self.log_critical(env)
    return env
```

we see the `GIT_SSH_COMMAND` environment variable is set to the problematic value:

```
CRITICAL: { ..., 'GIT_SSH_COMMAND': 'git -i /home/__alias__/.ssh/id_rsa'}
```

The change introduces a new attribute `ssh_executable` which defaults to `'ssh'`
solving this error and allowing valid customisation of the ssh command.

Ticket: None
Changelog: None
