### PR TITLE
CFE-3729: Refactored ansible custom promise to be Python 3.5 compatible

### DIFF
--- a/promise_types/ansible/ansible_promise.py
+++ b/promise_types/ansible/ansible_promise.py
@@ -78,7 +78,7 @@ class AnsiblePromiseTypeModule(PromiseModule):
 
         def must_be_absolute(v):
             if not os.path.isabs(v):
-                raise ValidationError(f"Must be an absolute path, not '{v}'")
+                raise ValidationError("Must be an absolute path, not '{v}'".format(v=v))
 
         self.add_attribute(
             "playbook", str, default_to_promiser=True, validator=must_be_absolute
@@ -155,7 +155,7 @@ class AnsiblePromiseTypeModule(PromiseModule):
 
         exit_code = pbex.run()
         if exit_code != 0:
-            classes.append(f"{safe_promiser}_failed")
+            classes.append("{safe_promiser}_failed".format(safe_promiser=safe_promiser))
             result = Result.NOT_KEPT
         elif callback.changed:
             result = Result.REPAIRED

--- a/promise_types/ansible/ansible_promise.py
+++ b/promise_types/ansible/ansible_promise.py
@@ -135,7 +135,8 @@ class AnsiblePromiseTypeModule(PromiseModule):
 
         loader = DataLoader()
         inventory = InventoryManager(
-            loader=loader, sources=(model.inventory,) if model.inventory else (),
+            loader=loader,
+            sources=(model.inventory,) if model.inventory else (),
         )
 
         variable_manager = VariableManager(


### PR DESCRIPTION
Testing was done by running the example.cf with python3.5 interpreter

Ticket: CFE-3729
