### PR TITLE
Added `__repr__` to `AttributeObject`

### DIFF
--- a/libraries/python/cfengine.py
+++ b/libraries/python/cfengine.py
@@ -65,7 +65,11 @@ class AttributeObject(object):
     def __init__(self, d):
         for key, value in d.items():
             setattr(self, key, value)
-
+    def __repr__(self):
+        return "{}({})".format(
+            self.__class__.__qualname__,
+            ", ".join("{}={!r}".format(k, v) for k, v in self.__dict__.items())
+        )
 
 class ValidationError(Exception):
     def __init__(self, message):


### PR DESCRIPTION
The `__repr__` magic method can ease debugging by allowing pretty printing of
the object itself instead of fiddling with individual attributes.
```python
>>> print(attr_obj)
AttributeObject(attr1='some_value', attr2=1)
```

Ticket: None
