### PR TITLE
ENT-7423: Added implementation for iptables custom promise `flush` command

### DIFF
--- a/promise_types/iptables/test.cf
+++ b/promise_types/iptables/test.cf
@@ -8,8 +8,11 @@ body common control
 {
     bundlesequence => {
        aggressive_policy,
+       input_flushed,
+       all_flushed,
     };
 }
+
 bundle agent aggressive_policy
 {
   iptables:
@@ -21,3 +24,26 @@ bundle agent aggressive_policy
   reports:
       "--- ${this.bundle} ---";
 }
+
+bundle agent input_flushed
+{
+  iptables:
+      "input_flushed"
+        command => "flush",
+        chain => "INPUT";
+
+  reports:
+      "--- ${this.bundle} ---";
+}
+
+bundle agent all_flushed
+{
+  iptables:
+      "all_flushed"
+        command => "flush",
+        chain => "ALL";
+
+  reports:
+      "--- ${this.bundle} ---";
+}
+


### PR DESCRIPTION
Testing of the module was done as follows:
```shell
iptables -F
for _ in {1..3}; do
    iptables -A INPUT -j ACCEPT
    iptables -A OUTPUT -j ACCEPT
done
iptables -L
#Chain INPUT (policy ACCEPT)
#target     prot opt source               destination
#ACCEPT     all  --  anywhere             anywhere
#ACCEPT     all  --  anywhere             anywhere
#ACCEPT     all  --  anywhere             anywhere
#
#Chain FORWARD (policy ACCEPT)
#target     prot opt source               destination
#
#Chain OUTPUT (policy ACCEPT)
#target     prot opt source               destination
#ACCEPT     all  --  anywhere             anywhere
#ACCEPT     all  --  anywhere             anywhere
#ACCEPT     all  --  anywhere             anywhere
```
By commenting out the other test bundles except `all_flushed` bundle:
```shell
cf-agent -KI test.cf
#R: --- all_flushed ---
#    info: Flushing 'ALL' chain(s) in table 'filter'
iptables -L
#Chain INPUT (policy ACCEPT)
#target     prot opt source               destination
#
#Chain FORWARD (policy ACCEPT)
#target     prot opt source               destination
#
#Chain OUTPUT (policy ACCEPT)
#target     prot opt source               destination
```
After filling up the INPUT, OUTPUT chains again and keeping only the `input_flushed` test bundle uncommented:

```shell
iptables -L
#Chain INPUT (policy ACCEPT)
#target     prot opt source               destination
#ACCEPT     all  --  anywhere             anywhere
#ACCEPT     all  --  anywhere             anywhere
#ACCEPT     all  --  anywhere             anywhere
#
#Chain FORWARD (policy ACCEPT)
#target     prot opt source               destination
#
#Chain OUTPUT (policy ACCEPT)
#target     prot opt source               destination
#ACCEPT     all  --  anywhere             anywhere
#ACCEPT     all  --  anywhere             anywhere
#ACCEPT     all  --  anywhere             anywhere
cf-agent -KI test.cf
#R: --- input_flushed ---
#    info: Flushing 'INPUT' chain(s) in table 'filter'
iptables -L
#Chain INPUT (policy ACCEPT)
#target     prot opt source               destination
#
#Chain FORWARD (policy ACCEPT)
#target     prot opt source               destination
#
#Chain OUTPUT (policy ACCEPT)
#target     prot opt source               destination
#ACCEPT     all  --  anywhere             anywhere
#ACCEPT     all  --  anywhere             anywhere
#ACCEPT     all  --  anywhere             anywhere
```
