### PR TITLE
ENT-7423: Added implementation for iptables custom promise `delete` command

### DIFF
--- a/promise_types/iptables/test.cf
+++ b/promise_types/iptables/test.cf
@@ -10,7 +10,21 @@ body common control
        aggressive_policy,
        input_flushed,
        all_flushed,
+       cfengine_website_rule_deleted,
     };
+}
+
+bundle agent cfengine_website_rule_deleted
+{
+  iptables:
+      "delete_accept_cfengine"
+        command => "delete",
+        chain => "INPUT",
+        source => "34.107.174.45",
+        target => "ACCEPT";
+
+  reports:
+      "--- ${this.bundle} ---";
 }
 
 bundle agent aggressive_policy


### PR DESCRIPTION
Testing of the module was done as follows:
```shell
iptables -S INPUT
#-P INPUT ACCEPT
#-A INPUT -j ACCEPT
#-A INPUT -j ACCEPT
#-A INPUT -s 34.107.174.45/32 -j ACCEPT
#-A INPUT -j ACCEPT
#-A INPUT -j ACCEPT
```
After commenting out all test bundles except for `cfengine_website_rule_deleted`:
```shell
cf-agent -KI test.cf
#R: --- cfengine_website_rule_deleted ---
#    info: Deleting rule '-D INPUT -s 34.107.174.45 -j ACCEPT' from table 'filter'
iptables -S INPUT
#-P INPUT ACCEPT
#-A INPUT -j ACCEPT
#-A INPUT -j ACCEPT
#-A INPUT -j ACCEPT
#-A INPUT -j ACCEPT
```
