### PR TITLE
ENT-7423: Added implementation of iptables custom promise `append` command

### DIFF
--- a/promise_types/iptables/test.cf
+++ b/promise_types/iptables/test.cf
@@ -7,20 +7,50 @@ promise agent iptables
 body common control
 {
     bundlesequence => {
+       cfengine_com_accepted,
+       telnet_dropped,
+       cfengine_com_deleted,
        aggressive_policy,
        input_flushed,
        all_flushed,
-       cfengine_website_rule_deleted,
     };
 }
 
-bundle agent cfengine_website_rule_deleted
+bundle agent cfengine_com_accepted
 {
   iptables:
-      "delete_accept_cfengine"
+      "accept_cfengine_com"
+        command => "append",
+        chain => "INPUT",
+        source => "34.107.174.45",
+        target => "ACCEPT";
+
+  reports:
+      "--- ${this.bundle} ---";
+}
+
+bundle agent telnet_dropped
+{
+  iptables:
+      "accept_cfengine_com"
+        command => "append",
+        chain => "INPUT",
+        protocol => "tcp",
+        destination_port => "23",
+        target => "DROP";
+
+  reports:
+      "--- ${this.bundle} ---";
+}
+
+bundle agent cfengine_com_deleted
+{
+  iptables:
+      "delete_accept_cfengine_com"
         command => "delete",
         chain => "INPUT",
         source => "34.107.174.45",
+        priority => "-1",
         target => "ACCEPT";
 
   reports:

--- a/promise_types/iptables/test.cf
+++ b/promise_types/iptables/test.cf
@@ -10,7 +10,21 @@ body common control
        aggressive_policy,
        input_flushed,
        all_flushed,
+       cfengine_website_rule_deleted,
     };
+}
+
+bundle agent cfengine_website_rule_deleted
+{
+  iptables:
+      "delete_accept_cfengine"
+        command => "delete",
+        chain => "INPUT",
+        source => "34.107.174.45",
+        target => "ACCEPT";
+
+  reports:
+      "--- ${this.bundle} ---";
 }
 
 bundle agent aggressive_policy


### PR DESCRIPTION
Testing of the module was done as follows:
```shell
iptables -S INPUT
#-P INPUT ACCEPT
```
By commenting out the other test bundles except `cfengine_com_accepted` bundle:
```shell
cf-agent -KI test.cf
#R: --- cfengine_com_accepted ---
#    info: Appending rule '-A INPUT -s 34.107.174.45/32 -m comment --comment "CF3:priority:-1" -j ACCEPT' on table 'filter'
iptables -S INPUT
#-P INPUT ACCEPT
#-A INPUT -s 34.107.174.45/32 -m comment --comment "CF3:priority:-1" -j ACCEPT
```
While keeping the previous bundle active and uncommenting the `telnet_dropped` bundle:
```shell
cf-agent -KI test.cf
#R: --- cfengine_com_accepted ---
#R: --- telnet_dropped ---
#    info: Appending rule '-A INPUT -p tcp -m tcp --dport 23 -m comment --comment "CF3:priority:-1" -j DROP' on table 'filter'
iptables -S INPUT
#-P INPUT ACCEPT
#-A INPUT -s 34.107.174.45/32 -m comment --comment "CF3:priority:-1" -j ACCEPT
#-A INPUT -p tcp -m tcp --dport 23 -m comment --comment "CF3:priority:-1" -j DROP
```
