### PR TITLE
ENT-7423: Added implementation of iptables custom promise `insert` command

### DIFF
--- a/promise_types/iptables/test.cf
+++ b/promise_types/iptables/test.cf
@@ -7,20 +7,50 @@ promise agent iptables
 body common control
 {
     bundlesequence => {
+       cfengine_com_accepted,
+       telnet_dropped,
+       cfengine_com_deleted,
        aggressive_policy,
        input_flushed,
        all_flushed,
-       cfengine_website_rule_deleted,
     };
 }
 
-bundle agent cfengine_website_rule_deleted
+bundle agent cfengine_com_accepted
 {
   iptables:
-      "delete_accept_cfengine"
+      "accept_cfengine_com"
+        command => "append",
+        chain => "INPUT",
+        source => "34.107.174.45",
+        target => "ACCEPT";
+
+  reports:
+      "--- ${this.bundle} ---";
+}
+
+bundle agent telnet_dropped
+{
+  iptables:
+      "accept_cfengine_com"
+        command => "append",
+        chain => "INPUT",
+        protocol => "tcp",
+        destination_port => "23",
+        target => "DROP";
+
+  reports:
+      "--- ${this.bundle} ---";
+}
+
+bundle agent cfengine_com_deleted
+{
+  iptables:
+      "delete_accept_cfengine_com"
         command => "delete",
         chain => "INPUT",
         source => "34.107.174.45",
+        priority => "-1",
         target => "ACCEPT";
 
   reports:

--- a/promise_types/iptables/test.cf
+++ b/promise_types/iptables/test.cf
@@ -10,7 +10,21 @@ body common control
        aggressive_policy,
        input_flushed,
        all_flushed,
+       cfengine_website_rule_deleted,
     };
+}
+
+bundle agent cfengine_website_rule_deleted
+{
+  iptables:
+      "delete_accept_cfengine"
+        command => "delete",
+        chain => "INPUT",
+        source => "34.107.174.45",
+        target => "ACCEPT";
+
+  reports:
+      "--- ${this.bundle} ---";
 }
 
 bundle agent aggressive_policy

--- a/promise_types/iptables/test.cf
+++ b/promise_types/iptables/test.cf
@@ -9,6 +9,7 @@ body common control
     bundlesequence => {
        cfengine_com_accepted,
        telnet_dropped,
+       accept_ssh_high_priority,
        cfengine_com_deleted,
        aggressive_policy,
        input_flushed,
@@ -38,6 +39,21 @@ bundle agent telnet_dropped
         protocol => "tcp",
         destination_port => "23",
         target => "DROP";
+
+  reports:
+      "--- ${this.bundle} ---";
+}
+
+bundle agent accept_ssh_high_priority
+{
+  iptables:
+      "accept_ssh"
+        command => "insert",
+        chain => "INPUT",
+        protocol => "tcp",
+        destination_port => "1",
+        priority => "4",
+        target => "ACCEPT";
 
   reports:
       "--- ${this.bundle} ---";


### PR DESCRIPTION
Testing of the module was done as follows:
```shell
iptables -S INPUT
#-P INPUT ACCEPT
```
By commenting out the other test bundles except `accept_ssh_high_priority` bundle:
```shell
cf-agent -KI test.cf
#R: --- accept_ssh_high_priority ---
#    info: Inserting rule '-I INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:4" -j ACCEPT' on table 'filter' with priority '4'
iptables -S INPUT
#-P INPUT ACCEPT
#-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:4" -j ACCEPT
```
## Valid Inputs
By changing the priority of the test bundle and running
```shell
cf-agent -KI test.cf && echo "=====" && iptables -S INPUT
```
we get the following results:
- priority "5":
```
R: --- accept_ssh_high_priority ---
    info: Inserting rule '-I INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:5" -j ACCEPT' on table 'filter' with priority '5'
=====
-P INPUT ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:4" -j ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:5" -j ACCEPT
```
- priority "3":
```
R: --- accept_ssh_high_priority ---
    info: Inserting rule '-I INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:3" -j ACCEPT' on table 'filter' with priority '3'
=====
-P INPUT ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:3" -j ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:4" -j ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:5" -j ACCEPT
```
- priority "123":
```
R: --- accept_ssh_high_priority ---
    info: Inserting rule '-I INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:123" -j ACCEPT' on table 'filter' with priority '123'
=====
-P INPUT ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:3" -j ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:4" -j ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:5" -j ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:123" -j ACCEPT
```
- priority "1":
```
R: --- accept_ssh_high_priority ---
    info: Inserting rule '-I INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:1" -j ACCEPT' on table 'filter' with priority '1'
=====
-P INPUT ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:1" -j ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:3" -j ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:4" -j ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:5" -j ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:123" -j ACCEPT
```
- not specified:
```
R: --- accept_ssh_high_priority ---
=====
-P INPUT ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:1" -j ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:3" -j ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:4" -j ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:5" -j ACCEPT
-A INPUT -p tcp -m tcp --dport 1 -m comment --comment "CF3:priority:123" -j ACCEPT
```
Note the lack of info reporting. Not specifying priority means insert at the top of the chain (priority 1)
## Invalid Inputs
Only `cf-agent -KI test.cf` is run this time:
- priority "-1"
```
R: --- accept_ssh_high_priority ---
   error: Command 'insert' only accepts 'priority' >=1 for iptables promise with promiser 'accept_ssh' (test.cf:50)
   error: Command 'insert' only accepts 'priority' >=1 for iptables promise with promiser 'accept_ssh' (test.cf:50)
   error: Command 'insert' only accepts 'priority' >=1 for iptables promise with promiser 'accept_ssh' (test.cf:50)
```
- priority "blah"
```
R: --- accept_ssh_high_priority ---
   error: Wrong type for attribute 'priority', requires 'int', not 'blah'(string) for iptables promise with promiser 'accept_ssh' (test.cf:50)
   error: Wrong type for attribute 'priority', requires 'int', not 'blah'(string) for iptables promise with promier 'accept_ssh' (test.cf:50)
   error: Wrong type for attribute 'priority', requires 'int', not 'blah'(string) for iptables promise with promiser 'accept_ssh' (test.cf:50)
```
s
