### PR TITLE
ENT-7423:     Added implementation of iptables custom promise `exclusive` command

### DIFF
--- a/promise_types/iptables/test.cf
+++ b/promise_types/iptables/test.cf
@@ -7,20 +7,50 @@ promise agent iptables
 body common control
 {
     bundlesequence => {
+       cfengine_com_accepted,
+       telnet_dropped,
+       cfengine_com_deleted,
        aggressive_policy,
        input_flushed,
        all_flushed,
-       cfengine_website_rule_deleted,
     };
 }
 
-bundle agent cfengine_website_rule_deleted
+bundle agent cfengine_com_accepted
 {
   iptables:
-      "delete_accept_cfengine"
+      "accept_cfengine_com"
+        command => "append",
+        chain => "INPUT",
+        source => "34.107.174.45",
+        target => "ACCEPT";
+
+  reports:
+      "--- ${this.bundle} ---";
+}
+
+bundle agent telnet_dropped
+{
+  iptables:
+      "accept_cfengine_com"
+        command => "append",
+        chain => "INPUT",
+        protocol => "tcp",
+        destination_port => "23",
+        target => "DROP";
+
+  reports:
+      "--- ${this.bundle} ---";
+}
+
+bundle agent cfengine_com_deleted
+{
+  iptables:
+      "delete_accept_cfengine_com"
         command => "delete",
         chain => "INPUT",
         source => "34.107.174.45",
+        priority => "-1",
         target => "ACCEPT";
 
   reports:

--- a/promise_types/iptables/test.cf
+++ b/promise_types/iptables/test.cf
@@ -10,7 +10,21 @@ body common control
        aggressive_policy,
        input_flushed,
        all_flushed,
+       cfengine_website_rule_deleted,
     };
+}
+
+bundle agent cfengine_website_rule_deleted
+{
+  iptables:
+      "delete_accept_cfengine"
+        command => "delete",
+        chain => "INPUT",
+        source => "34.107.174.45",
+        target => "ACCEPT";
+
+  reports:
+      "--- ${this.bundle} ---";
 }
 
 bundle agent aggressive_policy

--- a/promise_types/iptables/test.cf
+++ b/promise_types/iptables/test.cf
@@ -14,6 +14,7 @@ body common control
        aggressive_policy,
        input_flushed,
        all_flushed,
+       rule_exclusivity,
     };
 }
 
@@ -102,6 +103,40 @@ bundle agent all_flushed
       "all_flushed"
         command => "flush",
         chain => "ALL";
+
+  reports:
+      "--- ${this.bundle} ---";
+}
+
+bundle common allow_cfengine_and_ssh
+{
+  vars:
+    "rules" data => '{
+        "table": "filter",
+        "chain": "INPUT",
+        "rule_specs": {
+          "accept_cfengine": {
+            "source": "34.107.174.45",
+            "priority": -1,
+            "target": "ACCEPT"
+          },
+          "accept_ssh": {
+            "protocol": "tcp",
+            "destination_port": 22,
+            "priority": 4,
+            "target": "ACCEPT"
+          },
+        }
+    }';
+}
+
+bundle agent rule_exclusivity
+{
+  iptables:
+      "clean_non_cfengine_rules"
+        command => "exclusive",
+        chain => "${allow_cfengine_and_ssh.rules[chain]}",
+        rules => @{allow_cfengine_and_ssh.rules};
 
   reports:
       "--- ${this.bundle} ---";

--- a/promise_types/iptables/test.cf
+++ b/promise_types/iptables/test.cf
@@ -9,6 +9,7 @@ body common control
     bundlesequence => {
        cfengine_com_accepted,
        telnet_dropped,
+       accept_ssh_high_priority,
        cfengine_com_deleted,
        aggressive_policy,
        input_flushed,
@@ -38,6 +39,21 @@ bundle agent telnet_dropped
         protocol => "tcp",
         destination_port => "23",
         target => "DROP";
+
+  reports:
+      "--- ${this.bundle} ---";
+}
+
+bundle agent accept_ssh_high_priority
+{
+  iptables:
+      "accept_ssh"
+        command => "insert",
+        chain => "INPUT",
+        protocol => "tcp",
+        destination_port => "1",
+        priority => "4",
+        target => "ACCEPT";
 
   reports:
       "--- ${this.bundle} ---";


### PR DESCRIPTION
Testing of the module was done as follows:
```shell
iptables -S INPUT
#-P INPUT ACCEPT
```
By commenting out the other test bundles except `rule_exclusivity` bundle:
```shell
cf-agent -KI test.ct
#R: --- rule_exclusivity ---
```
That is expected as the chain is empty.
```shell
iptables -S INPUT
#-P INPUT ACCEPT
#-A INPUT -j ACCEPT
#-A INPUT -j DROP
#-A INPUT -s 1.2.3.4/32 -j DROP
cf-agent -KI test.cf
#R: --- rule_exclusivity ---
#    info: Ensuring only rules with rule_specs {'accept_cfengine': {'priority': -1, 'source': '34.107.174.45/32', 'target': 'ACCEPT'}, 'accept_ssh': {'destination_port': 22, 'priority': 4, 'protocol': 'tcp', 'target': 'ACCEPT'}} are present in 'INPUT' of table 'filter'
iptables -S INPUT
#-P INPUT ACCEPT
```
```shell
iptables -S INPUT
#-P INPUT ACCEPT
#-A INPUT -j DROP
#-A INPUT -j DROP
#-A INPUT -s 34.107.174.45/32 -m comment --comment "CF3:priority:-1" -j ACCEPT
#-A INPUT -j DROP
#-A INPUT -j DROP
cf-agent -KI test.cf
#R: --- rule_exclusivity ---
#    info: Ensuring only rules with rule_specs {'accept_cfengine': {'priority': -1, 'source': '34.107.174.45/32', 'target': 'ACCEPT'}, 'accept_ssh': {'destination_port': 22, 'priority': 4, 'protocol': 'tcp', 'target': 'ACCEPT'}} are present in 'INPUT' of table 'filter'
iptables -S INPUT
#-P INPUT ACCEPT
#-A INPUT -s 34.107.174.45/32 -m comment --comment "CF3:priority:-1" -j ACCEPT
```
## Error Handling
The data that `rules` expects a dictionary that accepts only 3 keys: `"table"`, `"chain"`, `"rule_specs"`. From them only `"rule_specs"` is required. The other two are only allowed for the user to keep similar rules in one data structure. The [README.md](./README.md) has been updated to explain this.
### Invalid Data Keys
```cfengine3
bundle common allow_cfengine_and_ssh
{
  vars:
    "rules" data => '{
      "table": "filter",
      "chain": "INPUT",
      "rule_specs": {},
      "some_key": "some_value"
    }';
}
```


```shell
cf-agent -KI test.cf
#R: --- rule_exclusivity ---
#   error: Dictionary for attribute 'rules' contains denied keys {'some_key'} for iptables promise with promiser 'clean_non_cfengine_rules' (test.cf:125)
#   error: Dictionary for attribute 'rules' contains denied keys {'some_key'} for iptables promise with promiser 'clean_non_cfengine_rules' (test.cf:125)
#   error: Dictionary for attribute 'rules' contains denied keys {'some_key'} for iptables promise with promiser 'clean_non_cfengine_rules' (test.cf:125)
```
### Missing Required Key
```cfengine3
bundle common allow_cfengine_and_ssh
{
  vars:
    "rules" data => '{
    }';
}
```
```shell
iptables -KI test.cf
#R: --- rule_exclusivity ---
#   error: At least key 'rule_specs' must be present in 'rules' attribute data for iptables promise with promiser 'clean_non_cfengine_rules' (test.cf:122)
#   error: At least key 'rule_specs' must be present in 'rules' attribute data for iptables promise with promiser 'clean_non_cfengine_rules' (test.cf:122)
#   error: At least key 'rule_specs' must be present in 'rules' attribute data for iptables promise with promiser 'clean_non_cfengine_rules' (test.cf:122)
```
### Warn When Empty rule_specs
```cfengine3
bundle common allow_cfengine_and_ssh
{
  vars:
    "rules" data => '{
        "rule_specs": {}
    }';
}
```
```shell
cf-agent -KI test.cf
#R: --- rule_exclusivity ---
# warning: Empty 'rule_specs' will flush the entire chain, consider using the 'flush' command instead
# warning: Empty 'rule_specs' will flush the entire chain, consider using the 'flush' command instead
# warning: Empty 'rule_specs' will flush the entire chain, consider using the 'flush' command instead
# warning: Empty 'rule_specs' will flush the entire chain, consider using the 'flush' command instead
# warning: Empty 'rule_specs' will flush the entire chain, consider using the 'flush' command instead
# warning: Empty 'rule_specs' will flush the entire chain, consider using the 'flush' command instead
```
### Wrong "rule_specs" Type
```cfengine3
bundle common allow_cfengine_and_ssh
{
  vars:
    "rules" data => '{
        "rule_specs": "bad_value"
    }';
}
```
```shel
cf-agent -KI test.cf
#R: --- rule_exclusivity ---
#   error: Value of 'rule_specs' must be a dictionary for iptables promise with promiser 'clean_non_cfengine_rules' (test.cf:122)
#   error: Value of 'rule_specs' must be a dictionary for iptables promise with promiser 'clean_non_cfengine_rules' (test.cf:122)
#   error: Value of 'rule_specs' must be a dictionary for iptables promise with promiser 'clean_non_cfengine_rules' (test.cf:122)
```

