### PR TITLE
CFE-3903: Groups promise type now supports custom bodies

### DIFF
--- a/promise-types/groups/README.md
+++ b/promise-types/groups/README.md
@@ -13,36 +13,59 @@
 
 ## Attributes
 
-| Name      | Type      | Description                                                      | Mandatory | Default |
-| --------- | --------- | -----------------------------------------------------------------| --------- | ------- |
-| `policy`  | `string`  | Whether group should be present or absent on the local host      | No        | present |
-| `members` | `string`  | JSON object containing attributes "include", "exclude" & "only"  | no        | -       |
-| `gid`     | `integer` | The GID of the group                                             | No        | -       |
+| Name      | Type                        | Description                                                                                     | Mandatory | Default |
+| --------- | --------------------------- | ----------------------------------------------------------------------------------------------- | --------- | ------- |
+| `policy`  | `string`                    | Whether group should be present or absent on the local host                                     | no        | present |
+| `members` | `string` / `data` / `body`  | JSON string / data container / custom body containing attributes "include", "exclude" & "only"  | no        | -       |
+| `gid`     | `integer`                   | The GID of the group                                                                            | no        | -       |
 
 ## Examples
 
 Present group `foo` including user `alice` and `bob`, but excluding user `malcom`:
 
 ```
+@if minimum_version(3.20)
+body members foo
+{
+  include => { "alice", "bob" };
+  exclude => { "malcom" };
+}
+@endif
+
 bundle agent main
 {
   groups:
-    "foo"
-      policy => "present",
-      members => '{ "include": ["alice", "bob"],
-                    "exclude": ["malcom"] }';
+      "foo"
+        policy => "present",
+@if minimum_version(3.20)
+        members => foo;
+@else
+        members => '{ "include": ["alice", "bob"],
+                      "exclude": ["malcom"] }';
+@endif
 }
 ```
 
 Present group `bar` with GID `123` including only user `alice`:
 
 ```
+@if minimum_version(3.20)
+body members bar
+{
+  only => { "alice" };
+}
+@endif
+
 bundle agent main
 {
   groups:
-    "bar"
-      members => '{ "only": ["alice"] }',
-      gid = 123;
+      "bar"
+@if minimum_version(3.20)
+        members => bar,
+@else
+        members => '{ "only": ["alice"] }',
+@endif
+        gid = 123;
 }
 ```
 
@@ -52,8 +75,8 @@ Absent group `baz`:
 bundle agent main
 {
   groups:
-    "baz"
-      policy => "absent";
+      "baz"
+        policy => "absent";
 }
 ```
 

--- a/promise-types/groups/README.md
+++ b/promise-types/groups/README.md
@@ -3,7 +3,7 @@
 ## Synopsis
 
 * *Name*: `groups`
-* *Version*: `0.1.2`
+* *Version*: `0.1.3`
 * *Description*: Manage local groups.
 * *Note*: This is an experimental version of a promise type, and may be changed in the future.
 

--- a/promise-types/groups/groups.cf
+++ b/promise-types/groups/groups.cf
@@ -1,7 +1,8 @@
 # Example policy illustraing the use of custom promise module groups.
 #
-# Note: As of 3.18.0, custom promise modules does not support bodies, thus
-# JSON strings are used to define members for now.
+# Note: As of 3.20.0, custom promise modules support the use of custom bodies.
+#       Versions before 3.20.0 uses JSON strings or data containers to define
+#       members instead.
 
 
 promise agent groups
@@ -11,38 +12,66 @@ promise agent groups
   interpreter => "/usr/bin/python3";
 }
 
-
-bundle common foo
+@if minimum_version(3.20)
+body members foo
 # @breif Define members for group foo using attributes `include` and
 #        `exclude`.
 {
-  vars:
-    "members" string => '{ "include": ["alice", "bob"],
-                           "exclude": ["malcom"] }';
+  include => { "alice", "bob" };
+  exclude => { "malcom" };
 }
-
-
-bundle common bar
-# @breif Define members for group bar using attribute `only`.
+@else
+bundle common foo
+# @breif Define members using JSON string.
 {
   vars:
-    "members" string => '{ "only": ["alice"] }';
+      "members"
+        string => '{ "include": ["alice", "bob"],
+                     "exclude": ["malcom"] }';
 }
+@endif
+
+
+@if minimum_version(3.20)
+body members bar
+# @breif Define members for group bar using attribute `only`.
+{
+  only => { "alice" };
+}
+@else
+bundle common bar
+# @brief Define members using data container.
+{
+  vars:
+      "members"
+        data => '{ "only": ["alice"] }';
+}
+@endif
 
 
 bundle agent example_groups
 # @breif Example groups promise statements.
 {
   groups:
-    "foo"
-      policy => "present",
-      members => "$(foo.members)";
-    "bar"
+      "foo"
+        policy => "present",
+@if minimum_version(3.20)
+        members => foo;
+@else
+        members => "$(foo.members)";
+@endif
+
+      "bar"
       # policy defaults to present
-      members => "$(bar.members)",
-      gid => "1234";
-    "baz"
-      policy => "absent";
+@if minimum_version(3.20)
+        members => bar,
+@else
+        members => "@(bar.members)",
+@endif
+        gid => "1234";
+
+      "baz"
+        policy => "absent";
 }
 
 
@@ -50,18 +79,18 @@ bundle agent example_users
 # @breif Create users for the groups example.
 {
   users:
-    "alice"
-      policy => "present";
-    "bob"
-      policy => "present";
-    "malcom"
-      policy => "present";
+      "alice"
+        policy => "present";
+      "bob"
+        policy => "present";
+      "malcom"
+        policy => "present";
 }
 
 
 bundle agent __main__
 {
   methods:
-    "example_users";
-    "example_groups";
+      "example_users";
+      "example_groups";
 }

--- a/promise-types/groups/groups.py
+++ b/promise-types/groups/groups.py
@@ -11,10 +11,6 @@ class GroupsPromiseTypeModule(PromiseModule):
         self._name_maxlen = 32
 
     def validate_promise(self, promiser, attributes):
-        # check promiser type
-        if type(promiser) is not str:
-            raise ValidationError("Invalid type for promiser: expected string")
-
         # check promiser value
         if self._name_regex.match(promiser) is None:
             self.log_warning(

--- a/promise-types/groups/groups.py
+++ b/promise-types/groups/groups.py
@@ -6,7 +6,7 @@ from cfengine import PromiseModule, ValidationError, Result
 
 class GroupsPromiseTypeModule(PromiseModule):
     def __init__(self):
-        super().__init__("groups_promise_module", "0.1.2")
+        super().__init__("groups_promise_module", "0.1.3")
         self._name_regex = re.compile(r"^[a-z_][a-z0-9_-]*[$]?$")
         self._name_maxlen = 32
 

--- a/promise-types/groups/groups.py
+++ b/promise-types/groups/groups.py
@@ -79,9 +79,20 @@ class GroupsPromiseTypeModule(PromiseModule):
 
         # check attribute members if present
         if "members" in attributes:
-            # parse json
-            members = json.loads(attributes["members"])
-            attributes["members"] = members
+            # Parse as JSON, if type is string
+            if type(attributes["members"]) is str:
+                try:
+                    attributes["members"] = json.loads(attributes["members"])
+                except json.JSONDecodeError:
+                    raise ValidationError(
+                        "Invalid value for attribute 'members': Could not parse JSON"
+                    )
+            # Type should be dict if custom body or data container is used instead
+            elif type(attributes["members"]) is not dict:
+                raise ValidationError(
+                    "Invalid type for attribute 'members': expected 'body', 'data' or 'string'"
+                )
+            members = attributes["members"]
 
             # check attribute only not used with attributes include or exclude
             if "only" in members and ("include" in members or "exclude" in members):
@@ -126,7 +137,11 @@ class GroupsPromiseTypeModule(PromiseModule):
 
         # parse json in attribute members
         if "members" in attributes:
-            attributes["members"] = json.loads(attributes["members"])
+            # if members attribute is passed as a string, parse it as json
+            if type(attributes["members"]) is str:
+                attributes["members"] = json.loads(attributes["members"])
+            else:
+                assert type(attributes["members"]) is dict
 
         # set policy to present by default, if not specified
         if "policy" not in attributes:


### PR DESCRIPTION
Depends on: https://github.com/cfengine/core/pull/4884

 - [x] test on 3.18.x
 - [x] test on master
