### PR TITLE
Added 7 uninstall modules

### DIFF
--- a/security/enable-aslr/README.md
+++ b/security/enable-aslr/README.md
@@ -30,5 +30,5 @@ $ cf-agent -KI
 ## Adding exceptions
 
 If ASLR cannot be enabled for some reason, you can add an exception with the `exception_enable_aslr` class.
-This class can be set from the **Host specific data** section in host info pages inside Mission Portal, the CFEngine Enterprise Web UI.
+This class can be set within `def.json` ([Augments](https://docs.cfengine.com/docs/master/reference-language-concepts-augments.html)), from policy, or in the **Host specific data** section in host info pages inside Mission Portal, the CFEngine Enterprise Web UI.
 

--- a/security/uninstall-apache/README.md
+++ b/security/uninstall-apache/README.md
@@ -1,0 +1,21 @@
+The Apache web server, `httpd`, allows you to host websites and files.
+To reduce attack surface, it's generally recommended to not run it and uninstall it where it's not needed.
+A web server which is "accidentally" running, could help an attacker get into the system, especially if it is running an older version or lacks proper security configuration.
+
+**Recommendation:** Ensure the Apache web server is only running where necessary, by uninstalling it on all other machines (by default).
+Explicitly specify which machines are allowed to run the web server.
+
+## Example
+
+If you try installing the package and running the agent with this module, you should see it get uninstalled:
+
+```
+$ yum install httpd
+$ cf-agent -KI
+    info: Successfully removed package 'httpd'
+```
+
+## Adding exceptions
+
+When you need to run the Apache web server on some hosts, you can add an exception with the `exception_uninstall_apache` class.
+This class can be set within `def.json` ([Augments](https://docs.cfengine.com/docs/master/reference-language-concepts-augments.html)), from policy, or in the **Host specific data** section in host info pages inside Mission Portal, the CFEngine Enterprise Web UI.

--- a/security/uninstall-apache/uninstall-apache.cf
+++ b/security/uninstall-apache/uninstall-apache.cf
@@ -1,0 +1,33 @@
+bundle agent uninstall_apache
+# @brief Makes sure the apache packages are not installed on the system.
+# Based on the OpenSCAP Security Guide for RHEL 7:
+# https://static.open-scap.org/ssg-guides/ssg-rhel7-guide-anssi_nt28_minimal.html
+# CFEngine policy based on this module:
+# https://build.cfengine.com/modules/uninstall-ftp/
+{
+  vars:
+    redhat|suse::
+      "pkg_name" slist => { "httpd" }; # Name in yum
+    debian::
+      "pkg_name" slist => { "apache2" }; # name in apt
+
+  classes:
+      "apache_allowed"
+        or => {
+          "hardening_apache_allowed",
+          "data:hardening_apache_allowed",
+          "exception_uninstall_apache",
+          "data:exception_uninstall_apache",
+        };
+
+  packages:
+    !apache_allowed::
+      "${pkg_name}"
+        policy => "absent",
+        if => isvariable("pkg_name");
+
+  reports:
+    !apache_allowed::
+      "warning: apache package name not known for this platform"
+        unless => isvariable("pkg_name");
+}

--- a/security/uninstall-bind/README.md
+++ b/security/uninstall-bind/README.md
@@ -1,0 +1,21 @@
+The `bind` package provides the `named` service, for running a DNS server.
+Most machines are not DNS servers, and don't need this package.
+To reduce attack surface, this package should be uninstalled when not necessary. 
+
+**Recommendation:** Ensure only DNS servers use the `bind` package by uninstalling it on all other hosts (by default).
+Explicitly define hosts which are DNS servers and thus need the `bind` package.
+
+## Example
+
+If you try installing the package and running the agent with this module, you should see it get uninstalled:
+
+```
+$ apt install bind
+$ cf-agent -KI
+    info: Successfully removed package 'bind'
+```
+
+## Adding exceptions
+
+If this package is really needed on some hosts, you can add an exception with the `exception_uninstall_bind` class.
+This class can be set within `def.json` ([Augments](https://docs.cfengine.com/docs/master/reference-language-concepts-augments.html)), from policy, or in the **Host specific data** section in host info pages inside Mission Portal, the CFEngine Enterprise Web UI.

--- a/security/uninstall-bind/uninstall-bind.cf
+++ b/security/uninstall-bind/uninstall-bind.cf
@@ -1,0 +1,33 @@
+bundle agent uninstall_bind
+# @brief Makes sure the bind packages are not installed on the system.
+# Based on the OpenSCAP Security Guide for RHEL 7:
+# https://static.open-scap.org/ssg-guides/ssg-rhel7-guide-anssi_nt28_minimal.html
+# CFEngine policy based on this module:
+# https://build.cfengine.com/modules/uninstall-ftp/
+{
+  vars:
+    redhat|suse::
+      "pkg_name" slist => { "bind" }; # Name in yum
+    debian::
+      "pkg_name" slist => { "bind" }; # name in apt
+
+  classes:
+      "bind_allowed"
+        or => {
+          "hardening_bind_allowed",
+          "data:hardening_bind_allowed",
+          "exception_uninstall_bind",
+          "data:exception_uninstall_bind",
+        };
+
+  packages:
+    !bind_allowed::
+      "${pkg_name}"
+        policy => "absent",
+        if => isvariable("pkg_name");
+
+  reports:
+    !bind_allowed::
+      "warning: bind package name not known for this platform"
+        unless => isvariable("pkg_name");
+}

--- a/security/uninstall-dhcp/README.md
+++ b/security/uninstall-dhcp/README.md
@@ -1,0 +1,24 @@
+The DHCP service and protocol are used to automatically assign IP addresses to hosts on a network.
+An alternative to DHCP is to manually assign static IP addresses to each host.
+In a typical home network, the WiFi router is running a DHCP server.
+Most machines in a network do not need to run a DHCP server, so it is recommended to uninstall it in order to reduce attack surface.
+
+**Recommendation:** Ensure only the DHCP server is using the DHCP server software, by uninstalling it everywhere else (by default).
+Explicitly define which machine(s) are DHCP servers and thus need to have the DHCP software installed.
+
+## Example
+
+If you try installing the package and running the agent with this module, you should see it get uninstalled:
+
+```
+$ yum install dhcp
+$ cf-agent -KI
+    info: Successfully removed package 'dhcp'
+```
+
+**Hint:** On Debian / `apt`-based systems, the package name is `isc-dhcp-server`.
+
+## Adding exceptions
+
+If this package is really needed on some hosts, you can add an exception with the `exception_uninstall_dhcp` class.
+This class can be set within `def.json` ([Augments](https://docs.cfengine.com/docs/master/reference-language-concepts-augments.html)), from policy, or in the **Host specific data** section in host info pages inside Mission Portal, the CFEngine Enterprise Web UI.

--- a/security/uninstall-dhcp/uninstall-dhcp.cf
+++ b/security/uninstall-dhcp/uninstall-dhcp.cf
@@ -1,0 +1,33 @@
+bundle agent uninstall_dhcp
+# @brief Makes sure the dhcp packages are not installed on the system.
+# Based on the OpenSCAP Security Guide for RHEL 7:
+# https://static.open-scap.org/ssg-guides/ssg-rhel7-guide-anssi_nt28_minimal.html
+# CFEngine policy based on this module:
+# https://build.cfengine.com/modules/uninstall-ftp/
+{
+  vars:
+    redhat|suse::
+      "pkg_name" slist => { "dhcp" }; # Name in yum
+    debian::
+      "pkg_name" slist => { "isc-dhcp-server" }; # name in apt
+
+  classes:
+      "dhcp_allowed"
+        or => {
+          "hardening_dhcp_allowed",
+          "data:hardening_dhcp_allowed",
+          "exception_uninstall_dhcp",
+          "data:exception_uninstall_dhcp",
+        };
+
+  packages:
+    !dhcp_allowed::
+      "${pkg_name}"
+        policy => "absent",
+        if => isvariable("pkg_name");
+
+  reports:
+    !dhcp_allowed::
+      "warning: dhcp package name not known for this platform"
+        unless => isvariable("pkg_name");
+}

--- a/security/uninstall-dovecot/README.md
+++ b/security/uninstall-dovecot/README.md
@@ -1,0 +1,23 @@
+The [`dovecot`](https://en.wikipedia.org/wiki/Dovecot_%28software%29) software is an open-source IMAP and POP3 server.
+Its primary purpose is to act as an email storage server.
+As most machines are not email servers, it is recommended to uninstall it when possible, to reduce attack surface.
+
+**Recommendation:** Ensure only the intended machines are running the `dovecot` software, by uninstalling it everywhere else (by default).
+Explicitly define which hosts in your infrastructure are email servers and need the `dovecot` software installed.
+
+## Example
+
+If you try installing the package and running the agent with this module, you should see it get uninstalled:
+
+```
+$ yum install dovecot
+$ cf-agent -KI
+    info: Successfully removed package 'dovecot'
+```
+
+**Hint:** On Debian / `apt`-based systems, the package name is `dovecot-core`.
+
+## Adding exceptions
+
+If this package is really needed on some hosts, you can add an exception with the `exception_uninstall_dovecot` class.
+This class can be set within `def.json` ([Augments](https://docs.cfengine.com/docs/master/reference-language-concepts-augments.html)), from policy, or in the **Host specific data** section in host info pages inside Mission Portal, the CFEngine Enterprise Web UI.

--- a/security/uninstall-dovecot/uninstall-dovecot.cf
+++ b/security/uninstall-dovecot/uninstall-dovecot.cf
@@ -1,0 +1,33 @@
+bundle agent uninstall_dovecot
+# @brief Makes sure the dovecot packages are not installed on the system.
+# Based on the OpenSCAP Security Guide for RHEL 7:
+# https://static.open-scap.org/ssg-guides/ssg-rhel7-guide-anssi_nt28_minimal.html
+# CFEngine policy based on this module:
+# https://build.cfengine.com/modules/uninstall-ftp/
+{
+  vars:
+    redhat|suse::
+      "pkg_name" slist => { "dovecot" }; # Name in yum
+    debian::
+      "pkg_name" slist => { "dovecot-core" }; # name in apt
+
+  classes:
+      "dovecot_allowed"
+        or => {
+          "hardening_dovecot_allowed",
+          "data:hardening_dovecot_allowed",
+          "exception_uninstall_dovecot",
+          "data:exception_uninstall_dovecot",
+        };
+
+  packages:
+    !dovecot_allowed::
+      "${pkg_name}"
+        policy => "absent",
+        if => isvariable("pkg_name");
+
+  reports:
+    !dovecot_allowed::
+      "warning: dovecot package name not known for this platform"
+        unless => isvariable("pkg_name");
+}

--- a/security/uninstall-rsh-server/README.md
+++ b/security/uninstall-rsh-server/README.md
@@ -29,7 +29,7 @@ Run or Save the report and see which hosts in your environment have `rsh-server`
 If you try installing the package and running the agent with this module, you should see it get uninstalled:
 
 ```
-$ sudo apt install rsh-server
+$ apt install rsh-server
 $ cf-agent -KI
     info: Successfully removed package 'rsh-server'
 ```
@@ -37,4 +37,4 @@ $ cf-agent -KI
 ## Adding exceptions
 
 If this package is really needed on some hosts, you can add an exception with the `exception_uninstall_rsh_server` class.
-This class can be set from the **Host specific data** section in host info pages inside Mission Portal, the CFEngine Enterprise Web UI.
+This class can be set within `def.json` ([Augments](https://docs.cfengine.com/docs/master/reference-language-concepts-augments.html)), from policy, or in the **Host specific data** section in host info pages inside Mission Portal, the CFEngine Enterprise Web UI.

--- a/security/uninstall-samba/README.md
+++ b/security/uninstall-samba/README.md
@@ -1,0 +1,21 @@
+The [Samba](https://en.wikipedia.org/wiki/Samba_%28software%29) software enables file and printer sharing and is commonly used in mixed Windows and Linux environments.
+To reduce attack surface, you should uninstall samba where it is not needed, for example if you are using other software for file sharing.
+
+**Recommendation:** Uninstall Samba when possible (when it is not needed).
+For infrastructures or environments which don't use it at all, uninstall it everywhere.
+If some of your hosts need to use it, explicitly define where it is needed, and uninstall it everywhere else.
+
+## Example
+
+If you try installing the package and running the agent with this module, you should see it get uninstalled:
+
+```
+$ yum install samba
+$ cf-agent -KI
+    info: Successfully removed package 'samba'
+```
+
+## Adding exceptions
+
+If this package is really needed on some hosts, you can add an exception with the `exception_uninstall_samba` class.
+This class can be set within `def.json` ([Augments](https://docs.cfengine.com/docs/master/reference-language-concepts-augments.html)), from policy, or in the **Host specific data** section in host info pages inside Mission Portal, the CFEngine Enterprise Web UI.

--- a/security/uninstall-samba/uninstall-samba.cf
+++ b/security/uninstall-samba/uninstall-samba.cf
@@ -1,0 +1,33 @@
+bundle agent uninstall_samba
+# @brief Makes sure the samba packages are not installed on the system.
+# Based on the OpenSCAP Security Guide for RHEL 7:
+# https://static.open-scap.org/ssg-guides/ssg-rhel7-guide-anssi_nt28_minimal.html
+# CFEngine policy based on this module:
+# https://build.cfengine.com/modules/uninstall-ftp/
+{
+  vars:
+    redhat|suse::
+      "pkg_name" slist => { "samba" }; # Name in yum
+    debian::
+      "pkg_name" slist => { "samba" }; # name in apt
+
+  classes:
+      "samba_allowed"
+        or => {
+          "hardening_samba_allowed",
+          "data:hardening_samba_allowed",
+          "exception_uninstall_samba",
+          "data:exception_uninstall_samba",
+        };
+
+  packages:
+    !samba_allowed::
+      "${pkg_name}"
+        policy => "absent",
+        if => isvariable("pkg_name");
+
+  reports:
+    !samba_allowed::
+      "warning: samba package name not known for this platform"
+        unless => isvariable("pkg_name");
+}

--- a/security/uninstall-squid/README.md
+++ b/security/uninstall-squid/README.md
@@ -1,0 +1,20 @@
+The [Squid](https://en.wikipedia.org/wiki/Squid_%28software%29) software is used for proxying and caching requests (HTTP, FTP, DNS, etc.).
+To reduce attack surface, it is recommended to uninstall squid when it is not needed.
+
+**Recommendation:** Uninstall Squid by default / where it is not needed, ensuring it won't be used by malicious attackers.
+If Squid is needed on some machines, explicitly define what hosts should have it installed.
+
+## Example
+
+If you try installing the package and running the agent with this module, you should see it get uninstalled:
+
+```
+$ apt install squid
+$ cf-agent -KI
+    info: Successfully removed package 'squid'
+```
+
+## Adding exceptions
+
+If this package is really needed on some hosts, you can add an exception with the `exception_uninstall_squid` class.
+This class can be set within `def.json` ([Augments](https://docs.cfengine.com/docs/master/reference-language-concepts-augments.html)), from policy, or in the **Host specific data** section in host info pages inside Mission Portal, the CFEngine Enterprise Web UI.

--- a/security/uninstall-squid/uninstall-squid.cf
+++ b/security/uninstall-squid/uninstall-squid.cf
@@ -1,0 +1,33 @@
+bundle agent uninstall_squid
+# @brief Makes sure the squid packages are not installed on the system.
+# Based on the OpenSCAP Security Guide for RHEL 7:
+# https://static.open-scap.org/ssg-guides/ssg-rhel7-guide-anssi_nt28_minimal.html
+# CFEngine policy based on this module:
+# https://build.cfengine.com/modules/uninstall-ftp/
+{
+  vars:
+    redhat|suse::
+      "pkg_name" slist => { "squid" }; # Name in yum
+    debian::
+      "pkg_name" slist => { "squid" }; # name in apt
+
+  classes:
+      "squid_allowed"
+        or => {
+          "hardening_squid_allowed",
+          "data:hardening_squid_allowed",
+          "exception_uninstall_squid",
+          "data:exception_uninstall_squid",
+        };
+
+  packages:
+    !squid_allowed::
+      "${pkg_name}"
+        policy => "absent",
+        if => isvariable("pkg_name");
+
+  reports:
+    !squid_allowed::
+      "warning: squid package name not known for this platform"
+        unless => isvariable("pkg_name");
+}

--- a/security/uninstall-talk/README.md
+++ b/security/uninstall-talk/README.md
@@ -10,7 +10,7 @@ This module provides an easy way to achieve this.
 If you try installing the package(s) and running the agent with this module, you should see it get uninstalled:
 
 ```
-$ sudo apt install talk
+$ apt install talk
 $ cf-agent -KI
     info: Successfully removed package 'talk'
 ```
@@ -18,4 +18,4 @@ $ cf-agent -KI
 ## Adding exceptions
 
 If this package is really needed on some hosts, you can add an exception with the `exception_uninstall_talk` class.
-This class can be set from the **Host specific data** section in host info pages inside Mission Portal, the CFEngine Enterprise Web UI.
+This class can be set within `def.json` ([Augments](https://docs.cfengine.com/docs/master/reference-language-concepts-augments.html)), from policy, or in the **Host specific data** section in host info pages inside Mission Portal, the CFEngine Enterprise Web UI.

--- a/security/uninstall-xinetd/README.md
+++ b/security/uninstall-xinetd/README.md
@@ -1,0 +1,25 @@
+The [Extended Internet Service Daemon](https://en.wikipedia.org/wiki/Xinetd), `xinetd`, allows you to start services on request.
+This can be useful, allowing you to host many different network based services, while `xinetd` is the only daemon running.
+When a network request arrives, `xinetd` determines which service to start and relay the request to.
+If this kind of functionailty is not needed, it is recommended to uninstall it.
+An alternative to `xinetd` is [`systemd`](https://en.wikipedia.org/wiki/Systemd), with the socket activation feature.
+Since most Linux systems use `systemd` already, you don't have to install and rely on an extra piece of software, if you use that. 
+
+**Recommendation:** Uninstall `xinetd` (by default) wherever it is not needed.
+If some hosts need to use `xinetd`, explicitly define them.
+Consider using `systemd` socket activation instead of `xinetd`.
+
+## Example
+
+If you try installing the package(s) and running the agent with this module, you should see it get uninstalled:
+
+```
+$ apt install xinetd
+$ cf-agent -KI
+    info: Successfully removed package 'xinetd'
+```
+
+## Adding exceptions
+
+If this package is really needed on some hosts, you can add an exception with the `exception_uninstall_xinetd` class.
+This class can be set within `def.json` ([Augments](https://docs.cfengine.com/docs/master/reference-language-concepts-augments.html)), from policy, or in the **Host specific data** section in host info pages inside Mission Portal, the CFEngine Enterprise Web UI.

--- a/security/uninstall-xinetd/uninstall-xinetd.cf
+++ b/security/uninstall-xinetd/uninstall-xinetd.cf
@@ -1,0 +1,33 @@
+bundle agent uninstall_xinetd
+# @brief Makes sure the xinetd packages are not installed on the system.
+# Based on the OpenSCAP Security Guide for RHEL 7:
+# https://static.open-scap.org/ssg-guides/ssg-rhel7-guide-anssi_nt28_minimal.html
+# CFEngine policy based on this module:
+# https://build.cfengine.com/modules/uninstall-ftp/
+{
+  vars:
+    redhat|suse::
+      "pkg_name" slist => { "xinetd" }; # Name in yum
+    debian::
+      "pkg_name" slist => { "xinetd" }; # name in apt
+
+  classes:
+      "xinetd_allowed"
+        or => {
+          "hardening_xinetd_allowed",
+          "data:hardening_xinetd_allowed",
+          "exception_uninstall_xinetd",
+          "data:exception_uninstall_xinetd",
+        };
+
+  packages:
+    !xinetd_allowed::
+      "${pkg_name}" -> { "CCE-27354-0" }
+        policy => "absent",
+        if => isvariable("pkg_name");
+
+  reports:
+    !xinetd_allowed::
+      "warning: xinetd package name not known for this platform"
+        unless => isvariable("pkg_name");
+}


### PR DESCRIPTION
- Added 'uninstall-apache' module
- Added 'uninstall-dhcp' module
- Added 'uninstall-bind' module
- Added 'uninstall-dovecot' module
- Added 'uninstall-samba' module
- Added 'uninstall-squid' module
- Added 'uninstall-xinetd' module
- Small README improvements for enable-aslr, uninstall-rsh-server and uninstall-talk
