### PR TITLE
Added another name for bind package in apt

### DIFF
--- a/security/uninstall-bind/README.md
+++ b/security/uninstall-bind/README.md
@@ -10,10 +10,12 @@ Explicitly define hosts which are DNS servers and thus need the `bind` package.
 If you try installing the package and running the agent with this module, you should see it get uninstalled:
 
 ```
-$ apt install bind
+$ yum install bind
 $ cf-agent -KI
     info: Successfully removed package 'bind'
 ```
+
+**Hint:** On Debian / `apt`-based machines, the package is sometimes called `bind9`.
 
 ## Adding exceptions
 

--- a/security/uninstall-bind/uninstall-bind.cf
+++ b/security/uninstall-bind/uninstall-bind.cf
@@ -9,7 +9,7 @@ bundle agent uninstall_bind
     redhat|suse::
       "pkg_name" slist => { "bind" }; # Name in yum
     debian::
-      "pkg_name" slist => { "bind" }; # name in apt
+      "pkg_name" slist => { "bind", "bind9" }; # name in apt
 
   classes:
       "bind_allowed"


### PR DESCRIPTION
According to the OpenSCAP guide, it should be named bind. However on
my Ubuntu machine, it is called bind9. Better remove both then.
