### PR TITLE
Add a 'meta' attribute to validate/evaluate_promise

### DIFF
--- a/examples/git-using-lib/git_using_lib.py
+++ b/examples/git-using-lib/git_using_lib.py
@@ -4,9 +4,9 @@ from cfengine import PromiseModule, ValidationError, Result
 
 class GitPromiseTypeModule(PromiseModule):
     def __init__(self, **kwargs):
-        super().__init__("git_promise_module", "0.0.2", **kwargs)
+        super().__init__("git_promise_module", "0.0.3", **kwargs)
 
-    def validate_promise(self, promiser, attributes):
+    def validate_promise(self, promiser, attributes, meta):
         if not promiser.startswith("/"):
             raise ValidationError(f"File path '{promiser}' must be absolute")
         for name, value in attributes.items():
@@ -15,7 +15,7 @@ class GitPromiseTypeModule(PromiseModule):
             if name == "repo" and type(value) is not str:
                 raise ValidationError(f"'repo' must be string for git promise types")
 
-    def evaluate_promise(self, promiser, attributes):
+    def evaluate_promise(self, promiser, attributes, meta):
         folder = promiser
         url = attributes["repo"]
 

--- a/examples/gpg/gpg.py
+++ b/examples/gpg/gpg.py
@@ -48,7 +48,7 @@ from cfengine import PromiseModule, ValidationError, Result
 
 class GpgKeysPromiseTypeModule(PromiseModule):
     def __init__(self):
-        super().__init__("gpg_keys_promise_module", "0.0.1")
+        super().__init__("gpg_keys_promise_module", "0.0.2")
 
     def gpg_import_ascii(self, homedir, ascii):
         with Popen(
@@ -103,7 +103,7 @@ class GpgKeysPromiseTypeModule(PromiseModule):
                 proc.communicate()
                 self.log_error(f"Timed out querying for gpg key '{user_id}'")
 
-    def validate_promise(self, promiser, attributes):
+    def validate_promise(self, promiser, attributes, meta):
         if not promiser.startswith("/"):
             raise ValidationError(
                 f"Promiser '{promiser}' for 'gpg_keys' promise must be an absolute path"
@@ -113,7 +113,7 @@ class GpgKeysPromiseTypeModule(PromiseModule):
                 f"Required attribute 'keylist' missing for 'gpg_keys' promise"
             )
 
-    def evaluate_promise(self, promiser, attributes):
+    def evaluate_promise(self, promiser, attributes, meta):
         keylist_json = self.clean_storejson_output(attributes["keylist"])
         self.log_verbose(f"keylist_json is '{keylist_json}'")
 

--- a/examples/rss/rss.py
+++ b/examples/rss/rss.py
@@ -5,10 +5,10 @@ from cfengine import PromiseModule, ValidationError, Result
 
 class RssPromiseTypeModule(PromiseModule):
     def __init__(self):
-        super().__init__("rss_promise_module", "0.0.2")
+        super().__init__("rss_promise_module", "0.0.3")
 
 
-    def validate_promise(self, promiser, attributes):
+    def validate_promise(self, promiser, attributes, meta):
         # check promiser type
         if type(promiser) is not str:
             raise ValidationError("invalid type for promiser: expected string")
@@ -43,7 +43,7 @@ class RssPromiseTypeModule(PromiseModule):
                 raise ValidationError(f"Invalid value '{select}' for attribute select: must be newest, oldest or random")
 
 
-    def evaluate_promise(self, promiser, attributes):
+    def evaluate_promise(self, promiser, attributes, meta):
         # get attriute feed
         feed = attributes['feed']
 

--- a/examples/site-up/site_up.py
+++ b/examples/site-up/site_up.py
@@ -7,13 +7,13 @@ from cfengine import PromiseModule, ValidationError, Result
 
 class SiteUpPromiseTypeModule(PromiseModule):
     def __init__(self):
-        super().__init__("site_up_promise_module", "0.0.1")
+        super().__init__("site_up_promise_module", "0.0.2")
 
-    def validate_promise(self, promiser, attributes):
+    def validate_promise(self, promiser, attributes, meta):
         if not self.is_url_valid(promiser):
             raise ValidationError(f"URL '{promiser}' is invalid")
 
-    def evaluate_promise(self, url, attributes):
+    def evaluate_promise(self, url, attributes, meta):
         ssl_ctx = ssl.create_default_context()
         if (
             "skip_ssl_verification" in attributes

--- a/libraries/python/README.org
+++ b/libraries/python/README.org
@@ -1,0 +1,7 @@
+* CFEngine Python promise types library
+
+A library for CFEngine custom promise types implemented in Python. It provides
+the =PromiseModule= base class and many helper values and mechanisms that
+facilitates creation of custom promises.
+
+See [[https://github.com/cfengine/modules/blob/master/examples/git-using-lib/git_using_lib.py][examples/git-using-lib]] for an example of how this library can be used.

--- a/libraries/python/cfengine.py
+++ b/libraries/python/cfengine.py
@@ -214,7 +214,7 @@ class PromiseModule:
         elif operation == "validate_promise":
             self._handle_validate(promiser, attributes, request)
         elif operation == "evaluate_promise":
-            self._handle_evaluate(promiser, attributes)
+            self._handle_evaluate(promiser, attributes, request)
         elif operation == "terminate":
             self._handle_terminate()
         else:
@@ -326,9 +326,10 @@ class PromiseModule:
         _put_response(self._response, self._out, self._record_file)
 
     def _handle_validate(self, promiser, attributes, request):
+        meta = {"promise_type": request.get("promise_type")}
         try:
-            self.validate_attributes(promiser, attributes)
-            returned = self.validate_promise(promiser, attributes)
+            self.validate_attributes(promiser, attributes, meta)
+            returned = self.validate_promise(promiser, attributes, meta)
             if returned is None:
                 # Good, expected
                 self._result = Result.VALID
@@ -367,10 +368,11 @@ class PromiseModule:
         self._add_result()
         _put_response(self._response, self._out, self._record_file)
 
-    def _handle_evaluate(self, promiser, attributes):
+    def _handle_evaluate(self, promiser, attributes, request):
         self._result_classes = None
+        meta = {"promise_type": request.get("promise_type")}
         try:
-            results = self.evaluate_promise(promiser, attributes)
+            results = self.evaluate_promise(promiser, attributes, meta)
 
             # evaluate_promise should return either a result or a (result, result_classes) pair
             if type(results) == str:
@@ -446,16 +448,16 @@ class PromiseModule:
         """Override if you want to modify promiser or attributes before validate or evaluate"""
         return (promiser, attributes)
 
-    def validate_attributes(self, promiser, attributes):
+    def validate_attributes(self, promiser, attributes, meta):
         """Override this if you want to prevent automatic validation"""
         return self._validate_attributes(promiser, attributes)
 
-    def validate_promise(self, promiser, attributes):
+    def validate_promise(self, promiser, attributes, meta):
         """Must override this or use validation through self.add_attribute()"""
         if not self._has_validation_attributes:
             raise NotImplementedError("Promise module must implement validate_promise")
 
-    def evaluate_promise(self, promiser, attributes):
+    def evaluate_promise(self, promiser, attributes, meta):
         raise NotImplementedError("Promise module must implement evaluate_promise")
 
     def protocol_terminate(self):

--- a/promise-types/ansible/ansible_promise.py
+++ b/promise-types/ansible/ansible_promise.py
@@ -73,7 +73,7 @@ if ANSIBLE_AVAILABLE:
 class AnsiblePromiseTypeModule(PromiseModule):
     def __init__(self, **kwargs):
         super(AnsiblePromiseTypeModule, self).__init__(
-            "ansible_promise_module", "0.1.1", **kwargs
+            "ansible_promise_module", "0.2.1", **kwargs
         )
 
         def must_be_absolute(v):
@@ -98,12 +98,12 @@ class AnsiblePromiseTypeModule(PromiseModule):
         safe_promiser = promiser.replace(",", "_")
         return (safe_promiser, attributes)
 
-    def validate_promise(self, promiser: str, attributes: Dict):
+    def validate_promise(self, promiser: str, attributes: Dict, meta: Dict):
         if not ANSIBLE_AVAILABLE:
             raise ValidationError("Ansible Python module not available")
 
     def evaluate_promise(
-        self, safe_promiser: str, attributes: Dict
+        self, safe_promiser: str, attributes: Dict, meta: Dict
     ) -> Tuple[str, List[str]]:
         model = self.create_attribute_object(safe_promiser, attributes)
 

--- a/promise-types/groups/groups.py
+++ b/promise-types/groups/groups.py
@@ -6,11 +6,11 @@ from cfengine import PromiseModule, ValidationError, Result
 
 class GroupsPromiseTypeModule(PromiseModule):
     def __init__(self):
-        super().__init__("groups_promise_module", "0.1.3")
+        super().__init__("groups_promise_module", "0.2.3")
         self._name_regex = re.compile(r"^[a-z_][a-z0-9_-]*[$]?$")
         self._name_maxlen = 32
 
-    def validate_promise(self, promiser, attributes):
+    def validate_promise(self, promiser, attributes, meta):
         # check promiser value
         if self._name_regex.match(promiser) is None:
             self.log_warning(
@@ -115,7 +115,7 @@ class GroupsPromiseTypeModule(PromiseModule):
                         % (duplicates, promiser)
                     )
 
-    def evaluate_promise(self, promiser, attributes):
+    def evaluate_promise(self, promiser, attributes, meta):
         # keep track of any repairs or failed repairs
         failed_repairs = 0
         repairs = 0

--- a/promise-types/http/http_promise_type.py
+++ b/promise-types/http/http_promise_type.py
@@ -20,10 +20,10 @@ class FileInfo:
 
 
 class HTTPPromiseModule(PromiseModule):
-    def __init__(self, name="http_promise_module", version="1.0.0", **kwargs):
+    def __init__(self, name="http_promise_module", version="2.0.0", **kwargs):
         super().__init__(name, version, **kwargs)
 
-    def validate_promise(self, promiser, attributes):
+    def validate_promise(self, promiser, attributes, meta):
         if "url" in attributes:
             url = attributes["url"]
             if type(url) != str:
@@ -91,7 +91,7 @@ class HTTPPromiseModule(PromiseModule):
             yield open(os.devnull, "wb")
 
 
-    def evaluate_promise(self, promiser, attributes):
+    def evaluate_promise(self, promiser, attributes, meta):
         url = attributes.get("url", promiser)
         method = attributes.get("method", "GET")
         headers = attributes.get("headers", dict())

--- a/promise-types/iptables/iptables.py
+++ b/promise-types/iptables/iptables.py
@@ -117,7 +117,7 @@ class IptablesPromiseTypeModule(PromiseModule):
     }
 
     def __init__(self, **kwargs):
-        super().__init__("iptables_promise_module", "0.1.2", **kwargs)
+        super().__init__("iptables_promise_module", "0.2.2", **kwargs)
 
         def must_be_one_of(items) -> Callable:
             def validator(v):
@@ -159,7 +159,7 @@ class IptablesPromiseTypeModule(PromiseModule):
         self.add_attribute("rules", dict)
         self.add_attribute("executable", str, default="iptables")
 
-    def validate_promise(self, promiser: str, attributes: dict):
+    def validate_promise(self, promiser: str, attributes: dict, meta: dict):
         command = attributes["command"]
 
         denied_attrs = self._collect_denied_attributes_of_command(command, attributes)
@@ -182,7 +182,7 @@ class IptablesPromiseTypeModule(PromiseModule):
         if command != "flush" and attributes.get("chain") == "ALL":
             raise ValidationError("Chain 'ALL' is only available for command 'flush'")
 
-    def evaluate_promise(self, promiser: str, attributes: dict):
+    def evaluate_promise(self, promiser: str, attributes: dict, meta: dict):
         safe_promiser = promiser.replace(",", "_")
 
         model = Model(


### PR DESCRIPTION
We need to be able to pass meta data about the promise to
validation and evaluation functions. For now, only promise type
is passed, but this shall be extended in the future.

Also, add a simple README.