### PR TITLE
ENT-10745: Fixed bundle name for conditional_installer input data

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -21,7 +21,7 @@
           "type": "string",
           "variable": "packages_to_uninstall",
           "namespace": "conditional_installer",
-          "bundle": "conditional_installer",
+          "bundle": "main",
           "label": "Uninstall",
           "question": "Which package(s) would you like to be uninstalled?"
         },
@@ -29,7 +29,7 @@
           "type": "list",
           "variable": "packages_to_install",
           "namespace": "conditional_installer",
-          "bundle": "conditional_installer",
+          "bundle": "main",
           "label": "Install",
           "subtype": [
             {

--- a/security/conditional-installer/main.cf
+++ b/security/conditional-installer/main.cf
@@ -13,7 +13,7 @@ bundle agent main
     # Mock data, should be based on input:
     # "packages_to_uninstall"
     #   string => 'talk,talk-server,telnet,telnet-server';
-    # 
+    #
     # "packages_to_install"
     #   data => '[
     #     {"packages": "talk,talk-server", "condition": "any", "why": ""},
@@ -33,7 +33,7 @@ bundle agent main
       # Determine packages to uninstall:
       "_packages_to_uninstall_unfiltered"
         slist => string_split("$(packages_to_uninstall)", ",", 100);
-  
+
       "_packages_to_uninstall"
         slist => difference(
           _packages_to_uninstall_unfiltered,


### PR DESCRIPTION
The policy looks for these variables in conditional_installer:main, not
conditional_installer:conditional_installer.

Ticket: ENT-10745
Changelog: Title