### PR TITLE
Added modules for autorun-inputs and autorun-bundles

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -8,6 +8,16 @@
       "subdirectory": "management/autorun",
       "steps": ["json def.json def.json"]
     },
+    "autorun-bundles": {
+      "description": "Enable automatic execution of bundles tagged 'autorun'.",
+      "subdirectory": "management/autorun-bundles",
+      "steps": ["json def.json def.json"]
+    },
+    "autorun-inputs": {
+      "description": "Enable automatic loading of policy files in 'services/autorun/'.",
+      "subdirectory": "management/autorun-inputs",
+      "steps": ["json def.json def.json"]
+    },
     "client-initiated-reporting": {
       "description": "Enable client initiated reporting and disable pull collection.",
       "subdirectory": "reporting/client-initiated-reporting",

--- a/management/autorun-bundles/README.md
+++ b/management/autorun-bundles/README.md
@@ -1,0 +1,3 @@
+# Enable autorun bundles
+
+Simple module to enable automatic execution of bundles tagged with `autorun`, using `def.json`.

--- a/management/autorun-bundles/def.json
+++ b/management/autorun-bundles/def.json
@@ -1,0 +1,5 @@
+{
+  "classes": {
+    "services_autorun_bundles": ["any"]
+  }
+}

--- a/management/autorun-inputs/README.md
+++ b/management/autorun-inputs/README.md
@@ -1,0 +1,3 @@
+# Enable autorun inputs
+
+Simple module to enable automatic loading of policy files that reside in `services/autorun/`, using `def.json`.

--- a/management/autorun-inputs/def.json
+++ b/management/autorun-inputs/def.json
@@ -1,0 +1,5 @@
+{
+  "classes": {
+    "services_autorun_inputs": ["any"]
+  }
+}


### PR DESCRIPTION
This simply mirrors the existing autorun bundle, but enables inputs and bundles
independently. This is useful in the context of migrating a policy set where you
have a mix of autorun policy that is present in services/autorun as well as
outside that directory.

This enables you to add your custom policy file tagged for autorun outside
services/autorun and have it depend on autorun-bundles.