### PR TITLE
Small consistency fixes to examples

### DIFF
--- a/examples/gpg/password-store-sync.cf
+++ b/examples/gpg/password-store-sync.cf
@@ -25,7 +25,7 @@ bundle agent main
 
   git:
     "/home/user/.password-store"
-      repo => "https://github.com/user/my-passwords";
+      repository => "https://github.com/user/my-passwords";
 
   gpg_keys:
     "/home/user/.gnupg"

--- a/examples/site-up/site_up.py
+++ b/examples/site-up/site_up.py
@@ -20,7 +20,8 @@ class SiteUpPromiseTypeModule(PromiseModule):
         if not self.is_url_valid(promiser):
             raise ValidationError(f"URL '{promiser}' is invalid")
 
-    def evaluate_promise(self, url, attributes, metadata):
+    def evaluate_promise(self, promiser, attributes, metadata):
+        url = promiser
         ssl_ctx = ssl.create_default_context()
         if (
             "skip_ssl_verification" in attributes


### PR DESCRIPTION
- Fixed repo vs repository attribute in gpg example promise type
- Renamed url parameter to promiser for consistency
