### PR TITLE
ENT-11525: Added module to disable recommendations from the MPF

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -23,6 +23,11 @@
       "subdirectory": "management/autorun-inputs",
       "steps": ["json def.json def.json"]
     },
+    "disable-recommendations": {
+      "description": "Disable all recommendations emitted from the Masterfiles Policy Framework (MPF).",
+      "subdirectory": "management/disable-recommendations",
+      "steps": ["json def.json def.json"]
+    },
     "client-initiated-reporting": {
       "description": "Enable client initiated reporting and disable pull collection.",
       "subdirectory": "reporting/client-initiated-reporting",

--- a/management/disable-recommendations/README.md
+++ b/management/disable-recommendations/README.md
@@ -1,0 +1,20 @@
+The Masterfiles Policy Framework (MPF) emits recommendations for various settings given the context and role of a host.
+
+For example, when federated reporting is enabled on an Enterprise hub, there is a recommendation to install gnu-parallel.
+
+```
+R: CFEngine recommends installing gnu parallel on federated reporting superhubs.
+```
+
+These can be useful, but you may want to disable the functionality to quiet your policy runs. This module facilitates disabling all recommendations by defining `default:cfengine_recommendations_disabled`, it is equivalent to editing the augments file (`/var/cfengine/masterfiles/def.json`) to:
+
+```json
+{
+  "classes": {
+    "default:cfengine_recommendations_disabled": {
+      "class_expressions": [ "any::" ],
+      "comment": "We disabled all recommendations emitted by the MPF to quiet policy output."
+    }
+  }
+}
+```

--- a/management/disable-recommendations/README.md
+++ b/management/disable-recommendations/README.md
@@ -6,7 +6,7 @@ For example, when federated reporting is enabled on an Enterprise hub, there is 
 R: CFEngine recommends installing gnu parallel on federated reporting superhubs.
 ```
 
-These can be useful, but you may want to disable the functionality to quiet your policy runs. This module facilitates disabling all recommendations by defining `default:cfengine_recommendations_disabled`, it is equivalent to editing the augments file (`/var/cfengine/masterfiles/def.json`) to:
+These can be useful, but you may want to disable the functionality to quiet your policy runs. This module facilitates disabling all recommendations by defining the `default:cfengine_recommendations_disabled` class. Thus it is an equivalent to editing the augments file (`/var/cfengine/masterfiles/def.json`) to:
 
 ```json
 {

--- a/management/disable-recommendations/def.json
+++ b/management/disable-recommendations/def.json
@@ -1,0 +1,8 @@
+{
+    "classes": {
+        "default:cfengine_recommendations_disabled": {
+            "class_expressions": [ "any::" ],
+            "comment": "We disabled all recommendations emitted by the MPF to quiet policy output."
+        }
+    }
+}


### PR DESCRIPTION
Ticket: ENT-11525
Changelog: Title

You can test this by adding my fork at the commit of the latest change, e.g.:

```
cfbs add https://github.com/nickanderson/modules@09b0a68d6cc16190f348878284a83bcfcddfffc0 disable-recommendations
```

Do we want this? I dunno, maybe it's better as a suggestion in MP rather than being a module. But we have other similar modules and I was just looking to improve quality of life for Vrata.