### PR TITLE
Always send important log messages from Python-based promise types 

### DIFF
--- a/libraries/python/cfengine.py
+++ b/libraries/python/cfengine.py
@@ -44,7 +44,13 @@ def _would_log(level_set, msg_level):
         # uknown level, assume it would be logged
         return True
 
-    return _LOG_LEVELS[msg_level] <= _LOG_LEVELS[level_set]
+    # info: log messages are special because they report changes done in promise
+    # evaluation which is important not only for showing to the user, but also
+    # for auditing/changelog and all modules are required to send info: messages
+    # for all REPAIRED promises. A similar logic applies to errors and warnings,
+    # IOW, anything at or above the info level.
+    return ((_LOG_LEVELS[msg_level] <= _LOG_LEVELS["info"]) or
+            (_LOG_LEVELS[msg_level] <= _LOG_LEVELS[level_set]))
 
 
 def _cfengine_type(typing):

--- a/libraries/python/cfengine.py
+++ b/libraries/python/cfengine.py
@@ -39,7 +39,7 @@ def _put_response(data, file, record_file=None):
         record_file.write("> \n")
 
 
-def _would_log(level_set, msg_level):
+def _should_send_log(level_set, msg_level):
     if msg_level not in _LOG_LEVELS:
         # uknown level, assume it would be logged
         return True
@@ -404,7 +404,7 @@ class PromiseModule:
         sys.exit(0)
 
     def _log(self, level, message):
-        if self._log_level is not None and not _would_log(self._log_level, level):
+        if self._log_level is not None and not _should_send_log(self._log_level, level):
             return
 
         # Message can be str or an object which implements __str__()


### PR DESCRIPTION
These messages inform about changes being done for repaired
promises or errors reported for failed promises, etc. and the
agent requires some whenever there's repaired/failed promise by
a custom promise type module.

Ticket: CFE-4406
Changelog: None