### PR TITLE
add newer class for purging policies

### DIFF
--- a/management/demo/def.json
+++ b/management/demo/def.json
@@ -2,6 +2,7 @@
     "classes": {
         "mpf_augments_control_enabled": ["any"],
         "cfengine_internal_purge_policies": ["any"],
+        "cfengine_internal_purge_policies_disabled": ["any"],
         "cfengine_mp_fr_dependencies_auto_install": ["any"]
     },
     "vars": {


### PR DESCRIPTION
Running on 3.24.x I get the following report/warning

```
R: `cfengine_internal_purge_policies` no longer has any effect. Please use `cfengine_internal_purge_policies_disabled` instead, to choose where you want to disable purging or remove the class completely if you want purging enabled everywhere (the new default in 3.18+).
```

I figured we should add both? So that this demo module works on older versions but the note mentions 3.18+ so maybe we can just remove instead).