### PR TITLE
Removed cfengine_internal_purge_policies as it is no longer needed

### DIFF
--- a/management/demo/def.json
+++ b/management/demo/def.json
@@ -1,7 +1,6 @@
 {
     "classes": {
         "mpf_augments_control_enabled": ["any"],
-        "cfengine_internal_purge_policies": ["any"],
         "cfengine_mp_fr_dependencies_auto_install": ["any"]
     },
     "vars": {


### PR DESCRIPTION
This class's behavior became the default in 3.18 and 3.18 is EOL so all supported versions have the desired behavior as the default.
