### PR TITLE
Fixed wrong bundle name in windows-openssh-server module

### DIFF
--- a/software/windows/windows-openssh-server.cf
+++ b/software/windows/windows-openssh-server.cf
@@ -2,7 +2,7 @@ bundle agent windows_openssh_server
 {
   methods:
     data:openssh_server_installed::
-      "openssh_server_installed";
+      "windows_openssh_server_installed";
 }
 
 bundle agent windows_openssh_server_installed


### PR DESCRIPTION
This caused openssh server to never be installed.
