### PR TITLE
CFE-4657: Set up GH Action which tests old python in cfengine/modules

### DIFF
--- a/.github/actions/set-up-legacy-python/action.yml
+++ b/.github/actions/set-up-legacy-python/action.yml
@@ -1,0 +1,30 @@
+name: "Set up legacy Python"
+description: "Sets up a specified Python version in a virtual environment using `pyenv`, installs dependencies, and caches the environment"
+inputs:
+  python-version:
+    required: true
+    description: "The Python version to set up"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/cache@v4
+      id: pyenv-cache
+      with:
+        path: |
+          /opt/hostedtoolcache/pyenv_root/2.4.20/x64/versions/${{ inputs.python-version }}
+        key: ${{ inputs.python-version }}-${{ hashFiles('requirements.txt') }}
+    - name: Set up Python ${{ inputs.python-version }} using pyenv
+      uses: gabrielfalcao/pyenv-action@32ef4d2c861170ce17ded56d10329d83f4c8f797
+      if: steps.pyenv-cache.outputs.cache-hit != 'true'
+      with:
+        default: "${{ inputs.python-version }}"
+        command: pip install -U pip
+    - name: Add Python ${{ inputs.python-version }} to PATH
+      run: echo "/opt/hostedtoolcache/pyenv_root/2.4.20/x64/versions/${{ inputs.python-version }}/bin" >> $GITHUB_PATH
+      shell: bash
+    - name: Install dependencies
+      run: |
+        python -m pip install flake8 pytest setuptools wheel
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      shell: bash

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,26 @@
+name: Python tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test-legacy:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.5.10", "3.6.15", "3.7.10", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up legacy Python ${{ matrix.python-version }}
+        uses: ./.github/actions/set-up-legacy-python
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Test cfengine_module_library is importable
+        run: python -c "import sys; sys.path.insert(0, 'libraries/python'); import cfengine_module_library; print('OK', sys.version)"


### PR DESCRIPTION
Also fix composite action to add pyenv to PATH, since pyenv-action step is skipped on cache hit

Ticket: CFE-4657